### PR TITLE
Ch03. 상세 기능 구현 - Batch 이용 기간에 따른 만료

### DIFF
--- a/src/main/java/com/example/pass/job/pass/ExpirePassesJobConfig.java
+++ b/src/main/java/com/example/pass/job/pass/ExpirePassesJobConfig.java
@@ -1,0 +1,87 @@
+package com.example.pass.job.pass;
+
+import com.example.pass.repository.pass.PassEntity;
+import com.example.pass.repository.pass.PassStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JpaCursorItemReader;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.batch.item.database.builder.JpaCursorItemReaderBuilder;
+import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Configuration
+public class ExpirePassesJobConfig {
+    private final int CHUNK_SIZE = 5;
+
+    // @EnableBatchProcessing로 인해 Bean으로 제공된 JobBuilderFactory, StepBuilderFactory
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final EntityManagerFactory entityManagerFactory;
+
+    public ExpirePassesJobConfig(JobBuilderFactory jobBuilderFactory, StepBuilderFactory stepBuilderFactory, EntityManagerFactory entityManagerFactory) {
+        this.jobBuilderFactory = jobBuilderFactory;
+        this.stepBuilderFactory = stepBuilderFactory;
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+    @Bean
+    public Job expirePassesJob() {
+        return this.jobBuilderFactory.get("expirePassesJob")
+                .start(expirePassesStep())
+                .build();
+    }
+
+    @Bean
+    public Step expirePassesStep() {
+        return this.stepBuilderFactory.get("expirePassesJob")
+                .<PassEntity, PassEntity>chunk(CHUNK_SIZE)
+                .reader(expirePassesItemReader())
+                .processor(expirePassesItemProcessor())
+                .writer(expirePassesItemWriter())
+                .build();
+    }
+
+    /**
+     * JpaCursorItemReader: JpaPagingItemReader만 지원하다가 Spring 4.3에서 추가
+     * 페이징 기법보다 높은 성능으로, 데이터 변경에 무관한 무결성 조회가 가능
+     */
+    @Bean
+    @StepScope
+    public JpaCursorItemReader<PassEntity> expirePassesItemReader() {
+        return new JpaCursorItemReaderBuilder<PassEntity>()
+                .name("expirePassesItemReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("select p from PassEntity p where p.status = :status and p.endedAt <= :endedAt")
+                .parameterValues(Map.of("status", PassStatus.PROGRESSED, "endedAt", LocalDateTime.now()))
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<PassEntity, PassEntity> expirePassesItemProcessor() {
+        return passEntity -> {
+            passEntity.setStatus(PassStatus.EXPIRED);
+            passEntity.setExpiredAt(LocalDateTime.now());
+            return passEntity;
+        };
+    }
+
+    /**
+     * JpaItemWriter: JPA의 영속성 관리를 위해 EntityManager를 필수로 설정해줘야 함.
+     */
+    @Bean
+    public JpaItemWriter<PassEntity> expirePassesItemWriter() {
+        return new JpaItemWriterBuilder<PassEntity>()
+                .entityManagerFactory(entityManagerFactory)
+                .build();
+    }
+}

--- a/src/main/java/com/example/pass/repository/pass/PassRepository.java
+++ b/src/main/java/com/example/pass/repository/pass/PassRepository.java
@@ -1,0 +1,17 @@
+package com.example.pass.repository.pass;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import javax.transaction.Transactional;
+
+public interface PassRepository extends JpaRepository<PassEntity, Integer> {
+    @Transactional
+    @Modifying
+    @Query(value = "UPDATE PassEntity p" +
+            "       SET p.remainingCount = :remainingCount," +
+            "           p.modifiedAt = CURRENT_TIMESTAMP" +
+            "       WHERE p.passSeq = :passSeq")
+    int updateRemainingCount(Integer passSeq, Integer remainingCount);
+}

--- a/src/main/java/com/example/pass/repository/pass/PassStatus.java
+++ b/src/main/java/com/example/pass/repository/pass/PassStatus.java
@@ -1,5 +1,5 @@
 package com.example.pass.repository.pass;
 
 public enum PassStatus {
-    READY, IN_PROGRESS, EXPIRED
+    READY, PROGRESSED, EXPIRED
 }

--- a/src/test/java/com/example/pass/config/TestBatchConfig.java
+++ b/src/test/java/com/example/pass/config/TestBatchConfig.java
@@ -1,0 +1,19 @@
+package com.example.pass.config;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableJpaAuditing
+@EnableAutoConfiguration
+@EnableBatchProcessing
+@EntityScan("com.example.pass.repository")
+@EnableJpaRepositories("com.example.pass.repository")
+@EnableTransactionManagement
+public class TestBatchConfig {
+}

--- a/src/test/java/com/example/pass/job/pass/ExpirePassesJobConfigTest.java
+++ b/src/test/java/com/example/pass/job/pass/ExpirePassesJobConfigTest.java
@@ -1,0 +1,70 @@
+package com.example.pass.job.pass;
+
+import com.example.pass.config.TestBatchConfig;
+import com.example.pass.repository.pass.PassEntity;
+import com.example.pass.repository.pass.PassRepository;
+import com.example.pass.repository.pass.PassStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@SpringBatchTest
+@SpringBootTest
+@ActiveProfiles("test")
+@ContextConfiguration(classes = {ExpirePassesJobConfig.class, TestBatchConfig.class})
+public class ExpirePassesJobConfigTest {
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private PassRepository passRepository;
+
+    @Test
+    public void test_expirePassesStep() throws Exception {
+        // Given
+        addPassEntities(10);
+
+        // When
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+        JobInstance jobInstance = jobExecution.getJobInstance();
+
+        // Then
+        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+        assertEquals("expirePassesJob", jobInstance.getJobName());
+    }
+
+    private void addPassEntities(int size) {
+        final LocalDateTime now = LocalDateTime.now();
+        final Random random = new Random();
+
+        List<PassEntity> passEntities = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            PassEntity passEntity = new PassEntity();
+            passEntity.setPackageSeq(1);
+            passEntity.setUserId("A" + 1000000 + i);
+            passEntity.setStatus(PassStatus.PROGRESSED);
+            passEntity.setRemainingCount(random.nextInt(11));
+            passEntity.setStartedAt(now.minusDays(60));
+            passEntity.setEndedAt(now.minusDays(1));
+            passEntities.add(passEntity);
+        }
+
+        passRepository.saveAll(passEntities);
+    }
+}


### PR DESCRIPTION
# Step
- Job의 배치처리를 정의하고 순차적인 단계를 캡슐화
- Job은 최소한 1개 이상의 Step을 거쳐야 하며 Job의 실제 일괄 처리를 제어하는 모든 정보가 들어있음

# JpaCursorItemReader

|속성|소개|기본값|
|---|-----|---|
|name|실행 컨텍스트 (ExecutionContext) 내에서 구분하기 위한 Key <br> `saveState`가 `true`로 설정된 경우 필수||
|entityManagerFactory|JPA를 사용하기 위한 EntityManagerFactory||
|queryString|사용한 JPQL 쿼리문||
|maxItemCount|조회할 최대 Item 수|Iteger.MAX_VALUE|
|currentItemCount|조회 Item의 시작 지점|0|
|saveState|동일 Job 재실행 시 실행 컨텍스트 내에서 ItemStream Support의 상태를 유지할지 여부|true|